### PR TITLE
improved articles on cores, esp Tensor Cores

### DIFF
--- a/gpu-glossary/device-hardware/core.md
+++ b/gpu-glossary/device-hardware/core.md
@@ -34,5 +34,4 @@ to store information,
 cores to transform it,
 and an
 [instruction scheduler](/gpu-glossary/device-hardware/warp-scheduler)
-to define specify and
-command transformations.
+to specify and command transformations.

--- a/gpu-glossary/device-hardware/core.md
+++ b/gpu-glossary/device-hardware/core.md
@@ -12,6 +12,27 @@ Examples of GPU core types include
 [Tensor Cores](/gpu-glossary/device-hardware/tensor-core).
 
 Though GPU cores are comparable to CPU cores in that they are the component that
-effects actual computations, this analogy can be misleading. The
-[SMs](/gpu-glossary/device-hardware/streaming-multiprocessor) are closer to
-being the equivalent of CPU cores.
+effects actual computations, this analogy can be quite misleading.
+Instead, it is perhaps more helpful to take the viewpoint of the
+[quantitative computer architect](https://archive.org/details/computerarchitectureaquantitativeapproach6thedition)
+and think of them as "pipes" into which data goes in
+and out of which transformed data is returned.
+These pipes are associated in turn with specific
+[instructions](/gpu-glossary/device-software/streaming-assembler)
+from the hardware's perspective and with different
+fundamental affordances of throughput from the programmers'
+(e.g. floating point matrix multiplication arithmetic throughput
+in the case of the
+[Tensor Cores](/gpu-glossary/device-hardware/tensor-core)).
+
+The
+[SMs](/gpu-glossary/device-hardware/streaming-multiprocessor)
+are closer to being the equivalent of CPU cores,
+in that they have
+[register memory](/gpu-glossary/device-hardware/register-file)
+to store information,
+cores to transform it,
+and an
+[instruction scheduler](/gpu-glossary/device-hardware/warp-scheduler)
+to define specify and
+command transformations.

--- a/gpu-glossary/device-hardware/cuda-core.md
+++ b/gpu-glossary/device-hardware/cuda-core.md
@@ -8,8 +8,8 @@ scalar arithmetic instructions.
 ![The internal architecture of an H100 SM. The CUDA Cores and Tensor Cores are depicted in green. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
 
 They are to be contrasted with the
-[Tensor Cores](/gpu-glossary/device-hardware/tensor-core), which execute matrix
-operations.
+[Tensor Cores](/gpu-glossary/device-hardware/tensor-core),
+which execute matrix operations.
 
 Unlike CPU cores, instructions issued to CUDA Cores are not generally
 independently scheduled. Instead, groups of cores are issued the same

--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -7,22 +7,158 @@ entire matrices with each instruction.
 
 ![The internal architecture of an H100 SM. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
 
-For example, the `mma`
-[PTX](/gpu-glossary/device-software/parallel-thread-execution) instructions
-(documented
-[here](https://docs.nvidia.com/cuda/parallel-thread-execution/#tensors))
-calculate D = AB + C for matrices A, B, C, and D. Operating on more data for a
-single instruction fetch dramatically reduces power requirements (see
+Operating on more data for a single instruction fetch dramatically
+reduces power requirements, which unlocks increased performance (see
 [this talk](https://youtu.be/kLiwvnr4L80?t=868) by Bill Dally, Chief Scientist
-at NVIDIA).
+at NVIDIA). As of the Blackwell
+[Streaming Multiprocessor (SM) Architecture](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
+generation, they are the only way to achieve the highest arithmetic throughput on NVIDIA GPUs.
+
+As an example, the `HMMA16.16816.F32`
+[SASS](/gpu-glossary/device-software/streaming-assembler) instruction
+calculates D = AB + C for matrices A, B, C, and D
+(where C is often the same physical matrix as D).
+The `MMA` stands for "Matrix Multiply and Accumulate".
+`HMMA16` indicates that the inputs are half-precision (`16` bits)
+and the `F32` indicates that the outputs are accumulated into
+`32` bit (aka single-precision) floats.
+
+`16816` is not single number larger than 16,000.
+Instead, the string of numbers `16`, `8`, `16` denote the dimensions of the matrices.
+These dimensions are generally named `m`, `k`, and `n` by NVIDIA, for example in
+[PTX](/gpu-glossary/device-software/parallel-thread-execution)
+instructions. The outer dimensions of A and B, aka `m` and `n`,
+come first and last, respectively, and the shared inner dimension for
+the accumulation, `k`, is in the middle. Multiplying these out,
+we see that the `HMMA16.16816.32` instruction performs 16 × 8 × 8 × 16 = 16,384
+multiply-accumulate (MAC) operations.
+
+Note that a single instruction in a single
+[thread](/gpu-glossary/device-software/thread)
+does not produce the entire matrix multiplication.
+Instead, the 32 threads of a
+[warp](/gpu-glossary/device-software/warp)
+cooperatively produce the result by executing the instruction together.
+Most of the per-instruction power overhead is in decoding, which is shared across a
+[warp](/gpu-glossary/device-software/warp)
+thanks to the
+[warp scheduler](/gpu-glossary/device-hardware/warp-scheduler).
+But even spread across those 32 threads, that's 512 = 16,384 ÷ 32 MACs per instruction.
+
+For this reason, it is helpful to think of Tensor Cores, and similar
+hardware like the systolic arrays in Google Tensor Processing Units (TPUs), as a form of
+[complex instruction set computer (CISC)](https://www.omgwiki.org/ddsf/doku.php?id=ddsf:public:guidebook:06_append:glossary:c:cisc)
+hardware. For more on this perspective, applied to TPUs, see
+[this talk by computer architect David Patterson](https://youtu.be/fhHAArxwzvQ?t=2072),
+who also [coined the term](https://www.semanticscholar.org/paper/4d3a941a5749dbf0dd39554f12597c449c3c07ff).
+
+That assembler-level instruction might be produced by a compiler to implement
+[PTX-level](/gpu-glossary/device-software/parallel-thread-execution)
+matrix-multiply-and-accumlate instructions like `wmma` (documented
+[here](https://docs.nvidia.com/cuda/parallel-thread-execution/#tensors)).
+Those instructions also calculate D = AB + C for matrices A, B, C, and D,
+but are generally compiled into many individual
+[SASS](/gpu-glossary/device-software/streaming-assembler)
+Tensor Core instructions that operate on smaller matrices.
+
+These instructions from the
+[PTX](/gpu-glossary/device-software/parallel-thread-execution)
+instruction set architecture are exposed in the high-level
+[CUDA C++ programming language](/gpu-glossary/host-software/cuda-c)
+as intrinsics.
+
+In reverse order, a line of
+[CUDA C++](/gpu-glossary/host-software/cuda-c)
+coding a matrix multiplication C = AB + C, like
+
+```cpp
+wmma::mma_sync(c, a, b, c);
+```
+
+might be compiled by
+[`nvcc`](/gpu-glossary/host-software/nvcc)
+to the
+[PTX](/gpu-glossary/device-software/parallel-thread-execution)
+intermediate representation as
+
+```ptx
+wmma.load.a.sync.aligned.col.m16n16k16.global.f16       {%r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9}, [%rd6], %r1;
+wmma.load.b.sync.aligned.row.m16n16k16.global.f16       {%r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17}, [%rd4], %r1;
+```
+
+and then finally compiled by `ptxas` to
+[SASS](/gpu-glossary/device-software/streaming-assembler)
+as
+
+```sass
+HMMA.1688.F32 R20, R12, R11, RZ   // 1
+HMMA.1688.F32 R24, R12, R17, RZ   // 2
+HMMA.1688.F32 R20, R14, R16, R20  // 3
+HMMA.1688.F32 R24, R14, R18, R24  // 4
+```
+
+The operands to the instruction can be read as
+D = AB + C,
+and so instruction 3 uses register 20 for its output D,
+registers 14 and 16 for its inputs A and B, respectively,
+and re-uses register 20 for its input D,
+effecting the computation
+`C += AB`.
+
+This program splits the accumulation dimension -- `k`,
+the column dimension of A and the row dimension of B -- across time:
+instructions 1 and 3 accumulate by reusing the "C matrix register" of 1,
+`R20`, as the "D matrix register" of 3 (`RZ` is a special-purpose "register"
+that contains the value `Z`ero).
+On machines that support `16816` matrix multiplications,
+we might expect these two instructions to run concurrently on the Tensor Core.
+
+The program splits `n`, the column dimension of B, across time and across space:
+that is, distinct instructions 1 and 3 (time) operate on distinct
+[registers](/gpu-glossary/device-software/registers)
+`R11` and `R16` (space) holding distinct columns in B. Within a block of
+eight rows and eight columns in B and within an entire column of A,
+calculations occur inside the Tensor Core concurrently, with respect to the instruction --
+each instruction handles all `m` rows of A for the given block of rows and columns from B.
+
+Outputs appear in row-major order by register index
+(`R20` and then `R24`),
+presumably laying them out in the
+[register file](/gpu-glossary/device-hardware/register-file)
+for faster writes to
+[shared memory](/gpu-glossary/device-software/shared-memory).
+
+Explore [this compiler output on Godbolt](https://godbolt.org/z/e6cqn8491)
+if you want to dive deeper. Note that this is far from a
+[utilization-maximizing](https://modal.com/blog/gpu-utilization-guide)
+matrix multiplication using Tensor Cores! For that, see
+[this worklog by Pranjal Shandkar](https://cudaforfun.substack.com/p/outperforming-cublas-on-h100-a-worklog).
+
+Programming Hopper and Blackwell Tensor Cores for maximum performance
+cannot be done in pure CUDA C++, requiring instead
+[PTX](/gpu-glossary/device-software/parallel-thread-execution)
+intrinsics for both computation and memory. It is generally recommended to instead
+use existing kernels from kernel libraries like
+[cuBLAS (CUDA Basic Linear Algebra Subroutines)](https://docs.nvidia.com/cuda/cublas/)
+or higher-level kernel programming interfaces like
+[CUTLASS (CUDA Templates for Linear Algebra Subroutines)](https://github.com/NVIDIA/cutlass).
+For an introduction to CUTLASS, see
+[this blog post series by Colfax Research](https://research.colfax-intl.com/cutlass-tutorial-wgmma-hopper/).
 
 Tensor Cores are much larger and less numerous than CUDA Cores. An H100 SXM5 has
-only four Tensor Cores per
-[Streaming Multiprocessor](/gpu-glossary/device-hardware/streaming-multiprocessor),
-to compared to hundreds of
+only four Tensor Cores per [SM](/gpu-glossary/device-hardware/streaming-multiprocessor),
+i.e. one per [Warp Scheduler](/gpu-glossary/device-hardware/warp-scheduler),
+compared to hundreds of
 [CUDA Cores](/gpu-glossary/device-hardware/cuda-core).
 
 Tensor Cores were introduced in the V100 GPU, which represented a major
 improvement in the suitability of NVIDIA GPUs for large neural network worloads.
 For more, see
 [the NVIDIA white paper introducing the V100](https://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf).
+
+The internals of Tensor Cores are unknown, and likely differ from
+[SM Architecture](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
+to
+[SM Architecture](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture).
+They are commonly assumed to be systolic arrays,
+but there is no consensus in the microbenchmarking literature.

--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -55,7 +55,7 @@ who also [coined the term](https://www.semanticscholar.org/paper/4d3a941a5749dbf
 That assembler-level instruction might be produced by a compiler to implement
 [PTX-level](/gpu-glossary/device-software/parallel-thread-execution)
 matrix-multiply-and-accumlate instructions like `wmma` (documented
-[here](https://docs.nvidia.com/cuda/parallel-thread-execution/#tensors)).
+[here](https://docs.nvidia.com/cuda/archive/12.8.0/parallel-thread-execution/index.html#warp-level-matrix-instructions)).
 Those instructions also calculate D = AB + C for matrices A, B, C, and D,
 but are generally compiled into many individual
 [SASS](/gpu-glossary/device-software/streaming-assembler)
@@ -121,13 +121,6 @@ eight rows and eight columns in B and within an entire column of A,
 calculations occur inside the Tensor Core concurrently, with respect to the instruction --
 each instruction handles all `m` rows of A for the given block of rows and columns from B.
 
-Outputs appear in row-major order by register index
-(`R20` and then `R24`),
-presumably laying them out in the
-[register file](/gpu-glossary/device-hardware/register-file)
-for faster writes to
-[shared memory](/gpu-glossary/device-software/shared-memory).
-
 Explore [this compiler output on Godbolt](https://godbolt.org/z/e6cqn8491)
 if you want to dive deeper. Note that this is far from a
 [utilization-maximizing](https://modal.com/blog/gpu-utilization-guide)
@@ -160,5 +153,5 @@ The internals of Tensor Cores are unknown, and likely differ from
 [SM Architecture](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
 to
 [SM Architecture](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture).
-They are commonly assumed to be systolic arrays,
+They are commonly assumed to be systolic arrays, like TPUs,
 but there is no consensus in the microbenchmarking literature.


### PR DESCRIPTION
Needs a check for URL typos, but the "core" content is in place.