### PR TITLE
add tensor core mma diagrams

### DIFF
--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -90,10 +90,12 @@ HMMA.1688.F32 R20, R14, R16, R20  // 3
 HMMA.1688.F32 R24, R14, R18, R24  // 4
 ```
 
-The operands to the instruction can be read as D = AB + C, and so instruction 3
+The operands to each `HMMA` instruction can be read as D = AB + C, and so instruction 3
 uses register 20 for its output D, registers 14 and 16 for its inputs A and B,
 respectively, and re-uses register 20 for its input D, effecting the computation
-`C += AB`.
+`C += AB`. See the diagram below.
+
+![Register usage in a Tensor Core MMA. See surrounding text for details.](themed-image://tensor-core-mma.svg)
 
 This program splits the accumulation dimension -- `k`, the column dimension of A
 and the row dimension of B -- across time: instructions 1 and 3 accumulate by


### PR DESCRIPTION
![Screenshot 2025-05-12 at 9 52 54 AM](https://github.com/user-attachments/assets/037674bf-a0ef-4411-b57f-55ef17efe47c)

should make the discussion of the mapping of the SASS onto the algebra easier to follow