### PR TITLE
Script for agg md files with and without links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 node_modules/**
+gpu-glossary.md

--- a/scripts/agg_to_markdown.py
+++ b/scripts/agg_to_markdown.py
@@ -1,65 +1,43 @@
+import argparse
 import os
 import re
 from functools import reduce
-from typing import List, Tuple
-import argparse
+from pathlib import Path
 
 
-def get_all_markdown_files(root_dir: str) -> List[str]:
-    return [
-        os.path.join(root, file)
-        for root, _, files in os.walk(root_dir)
-        for file in files
-        if file.endswith(".md")
-    ]
+def get_all_markdown_files(root_dir: str | Path) -> list[Path]:
+    return list(Path(root_dir).rglob("*.md"))
 
 
-def read_file_content(filepath: str) -> str:
-    with open(filepath, "r", encoding="utf-8") as f:
-        return f.read()
-
-
-def create_aggregated_markdown(root_dir: str, links: bool) -> str:
+def create_aggregated_markdown(root_dir: str | Path, links: bool) -> str:
     markdown_files = get_all_markdown_files(root_dir)
 
-    def process_file(filepath: str) -> str:
-        content = read_file_content(filepath)
-        return (
-            re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", content) if not links else content
-        )
-
-    processed_contents = list(map(process_file, markdown_files))
-    aggregated_content = []
-    for content in processed_contents:
-        aggregated_content.append(content)
-    return "\n".join(aggregated_content)
+    processed_contents = list(map(lambda f: f.read_text(), markdown_files))
+    return "\n\n".join(processed_contents)
 
 
-def get_program_arguments() -> Tuple[str, str, bool]:
+def get_program_arguments() -> (str, str, bool):
     parser = argparse.ArgumentParser(description="Aggregate markdown files.")
     parser.add_argument(
         "--root",
-        type=str,
+        type=Path,
         default="gpu-glossary",
         help="Root directory to search for markdown files.",
     )
     parser.add_argument(
-        "--output", type=str, default="gpu-glossary.md", help="Output markdown file."
+        "--output", type=Path, default="gpu-glossary.md", help="Output markdown file."
     )
     parser.add_argument(
-        "--links", type=str, default="false", help="Keep markdown links (true/false)."
+        "--no-links", action="store_true", help="Remove markdown links."
     )
     args = parser.parse_args()
-    links = args.links.lower() in ("true", "1", "yes", "on")
-    return args.root, args.output, links
+    return args.root, args.output, not args.no_links
 
 
 def main() -> None:
     root_dir, output_file, links = get_program_arguments()
-    aggregated_content = create_aggregated_markdown(root_dir, links)
-
-    with open(output_file, "w", encoding="utf-8") as f:
-        f.write(aggregated_content)
+    aggregated_markdown = create_aggregated_markdown(root_dir, links)
+    output_file.write_text(aggregated_markdown)
 
 
 if __name__ == "__main__":

--- a/scripts/agg_to_markdown.py
+++ b/scripts/agg_to_markdown.py
@@ -1,0 +1,52 @@
+import os
+import re
+from functools import reduce
+from typing import List, Tuple
+import argparse
+
+
+def get_all_markdown_files(root_dir: str) -> List[str]:
+    return [
+        os.path.join(root, file)
+        for root, _, files in os.walk(root_dir)
+        for file in files
+        if file.endswith('.md')
+    ]
+
+
+def read_file_content(filepath: str) -> str:
+    with open(filepath, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def create_aggregated_markdown(root_dir: str, links: bool) -> str:
+    markdown_files = get_all_markdown_files(root_dir)
+    
+    def process_file(filepath: str) -> str:
+        content = read_file_content(filepath)
+        return re.sub(r'\[.*?\]\(.*?\)[\s.,;:!?]*', '', content) if not links else content
+    
+    processed_contents = list(map(process_file, markdown_files))
+    return reduce(lambda acc, content: acc + content, processed_contents, "")
+
+
+def get_program_arguments() -> Tuple[str, str, bool]:
+    parser = argparse.ArgumentParser(description="Aggregate markdown files.")
+    parser.add_argument('--root', type=str, default='gpu-glossary', help='Root directory to search for markdown files.')
+    parser.add_argument('--output', type=str, default='gpu-glossary.md', help='Output markdown file.')
+    parser.add_argument('--links', type=str, default='false', help='Keep markdown links (true/false).')
+    args = parser.parse_args()
+    links = args.links.lower() in ('true', '1', 'yes', 'on')
+    return args.root, args.output, links
+
+
+def main() -> None:
+    root_dir, output_file, links = get_program_arguments()
+    aggregated_content = create_aggregated_markdown(root_dir, links)
+    
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(aggregated_content)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agg_to_markdown.py
+++ b/scripts/agg_to_markdown.py
@@ -10,22 +10,24 @@ def get_all_markdown_files(root_dir: str) -> List[str]:
         os.path.join(root, file)
         for root, _, files in os.walk(root_dir)
         for file in files
-        if file.endswith('.md')
+        if file.endswith(".md")
     ]
 
 
 def read_file_content(filepath: str) -> str:
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         return f.read()
 
 
 def create_aggregated_markdown(root_dir: str, links: bool) -> str:
     markdown_files = get_all_markdown_files(root_dir)
-    
+
     def process_file(filepath: str) -> str:
         content = read_file_content(filepath)
-        return re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', content) if not links else content
-    
+        return (
+            re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", content) if not links else content
+        )
+
     processed_contents = list(map(process_file, markdown_files))
     aggregated_content = []
     for content in processed_contents:
@@ -35,19 +37,28 @@ def create_aggregated_markdown(root_dir: str, links: bool) -> str:
 
 def get_program_arguments() -> Tuple[str, str, bool]:
     parser = argparse.ArgumentParser(description="Aggregate markdown files.")
-    parser.add_argument('--root', type=str, default='gpu-glossary', help='Root directory to search for markdown files.')
-    parser.add_argument('--output', type=str, default='gpu-glossary.md', help='Output markdown file.')
-    parser.add_argument('--links', type=str, default='false', help='Keep markdown links (true/false).')
+    parser.add_argument(
+        "--root",
+        type=str,
+        default="gpu-glossary",
+        help="Root directory to search for markdown files.",
+    )
+    parser.add_argument(
+        "--output", type=str, default="gpu-glossary.md", help="Output markdown file."
+    )
+    parser.add_argument(
+        "--links", type=str, default="false", help="Keep markdown links (true/false)."
+    )
     args = parser.parse_args()
-    links = args.links.lower() in ('true', '1', 'yes', 'on')
+    links = args.links.lower() in ("true", "1", "yes", "on")
     return args.root, args.output, links
 
 
 def main() -> None:
     root_dir, output_file, links = get_program_arguments()
     aggregated_content = create_aggregated_markdown(root_dir, links)
-    
-    with open(output_file, 'w', encoding='utf-8') as f:
+
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(aggregated_content)
 
 

--- a/scripts/agg_to_markdown.py
+++ b/scripts/agg_to_markdown.py
@@ -24,10 +24,13 @@ def create_aggregated_markdown(root_dir: str, links: bool) -> str:
     
     def process_file(filepath: str) -> str:
         content = read_file_content(filepath)
-        return re.sub(r'\[.*?\]\(.*?\)[\s.,;:!?]*', '', content) if not links else content
+        return re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', content) if not links else content
     
     processed_contents = list(map(process_file, markdown_files))
-    return reduce(lambda acc, content: acc + content, processed_contents, "")
+    aggregated_content = []
+    for content in processed_contents:
+        aggregated_content.append(content)
+    return "\n".join(aggregated_content)
 
 
 def get_program_arguments() -> Tuple[str, str, bool]:


### PR DESCRIPTION
Run the script to aggregate md files with or without links.

### Usage
```bash
python agg_to_markdown.py [--root DIR] [--output FILE] [--links true/false]
```

#### Arguments
--root - Root directory to search (default: gpu-glossary)
--output - Output file (default: gpu-glossary.md)
--links - Keep markdown links (default: false)

#### Examples
Basic usage (defaults)
```bash
python markdown_aggregator.py
```
Custom directory and output
```bash
python markdown_aggregator.py --root docs --output combined.md
```

Keep markdown links
```bash
python markdown_aggregator.py --links true
```