### PR TITLE
Fix doc typos and link

### DIFF
--- a/gpu-glossary/device-hardware/cuda-device-architecture.md
+++ b/gpu-glossary/device-hardware/cuda-device-architecture.md
@@ -42,7 +42,7 @@ and their main subcomponents are the
 For an accessible introduction to the history and design of CUDA hardware
 architectures, see [this blog post](https://fabiensanglard.net/cuda/) by Fabien
 Sanglard. That blog post cites its (high-quality) sources, like NVIDIA's
-[Fermi Compute Architecture white paper](https://fabiensanglard.net/cuda/Fermi_Compute_Architecture_Whitepaper.pdf).
+[Fermi Compute Architecture white paper](https://www.nvidia.com/content/pdf/fermi_white_papers/nvidia_fermi_compute_architecture_whitepaper.pdf).
 The white paper by
 [Lindholm et al. in 2008](https://www.cs.cmu.edu/afs/cs/academic/class/15869-f11/www/readings/lindholm08_tesla.pdf)
 introducing the Tesla architecture is both well-written and thorough. The

--- a/gpu-glossary/device-hardware/streaming-multiprocessor.md
+++ b/gpu-glossary/device-hardware/streaming-multiprocessor.md
@@ -58,7 +58,7 @@ sophisticated instruction prediction. This extra hardware limits the fraction of
 their silicon area, power, and heat budgets that CPUs can allocate to
 computation.
 
-![GPUs dedicate more of their area to compute (green), and less to control and caching (orange and blue), than do CPUs. Modified from a diagram in [Fabien Sanglard's blog](https://fabiensanglard.net/cuda), itself likely modifed from a diagram in [the CUDA C Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).](themed-image://cpu-vs-gpu.svg)
+![GPUs dedicate more of their area to compute (green), and less to control and caching (orange and blue), than do CPUs. Modified from a diagram in [Fabien Sanglard's blog](https://fabiensanglard.net/cuda), itself likely modified from a diagram in [the CUDA C Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).](themed-image://cpu-vs-gpu.svg)
 
 For programs or functions like neural network inference or sequential database
 scans for which it is relatively straightforward for programmers to

--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -51,7 +51,7 @@ who also
 
 That assembler-level instruction might be produced by a compiler to implement
 [PTX-level](/gpu-glossary/device-software/parallel-thread-execution)
-matrix-multiply-and-accumlate instructions like `wmma` (documented
+matrix-multiply-and-accumulate instructions like `wmma` (documented
 [here](https://docs.nvidia.com/cuda/archive/12.8.0/parallel-thread-execution/index.html#warp-level-matrix-instructions)).
 Those instructions also calculate D = AB + C for matrices A, B, C, and D, but
 are generally compiled into many individual
@@ -109,7 +109,7 @@ The first two instructions compute the matrix multiplication of the first eight
 columns of the input `a`, from `R12`, with the first eight rows of the input
 `b`, from `R11` and `R17`, producing a 16 by 16 matrix, which is stored in `R20`
 and `R24`. This is a sort of "outer product": a tall and skinny matrix
-mutliplied by a short and wide matrix. (`RZ` is a special-purpose "register"
+multiplied by a short and wide matrix. (`RZ` is a special-purpose "register"
 that contains the value `Z`ero).
 
 The second two instructions compute a similar "outer product" for the second

--- a/gpu-glossary/device-software/thread-hierarchy.md
+++ b/gpu-glossary/device-software/thread-hierarchy.md
@@ -38,7 +38,7 @@ At the highest level, multiple
 [thread blocks](/gpu-glossary/device-software/thread-block) are organized into a
 [thread block grid](/gpu-glossary/device-software/thread-block-grid) that spans
 the entire GPU. [Thread blocks](/gpu-glossary/device-software/thread-block) are
-strictly limited in their coordiation and communication. Blocks within a grid
+strictly limited in their coordination and communication. Blocks within a grid
 execute concurrently with respect to each other, with no guaranteed execution
 order. CUDA programs must be written so that any interleaving of blocks is
 valid, from fully serial to fully parallel. That means


### PR DESCRIPTION
First of all, I want to thank the authors for this amazing resource! It has been very helpful and the links to other resources have also been very useful.

I noticed a few small things while reading and have fixed them in this PR.

They include a few typos and one link adjustment. The link is a bit weird since the link is correct but when loading it in isolation it doesn't work. I looked into this and found out this is called "hotlink protection". Anyway, I found the same document on the official NVIDIA website and adjusted the link so it should work correctly now.