### PR TITLE
Tidy glossary grammar and clarify wording

### DIFF
--- a/gpu-glossary/contributors.md
+++ b/gpu-glossary/contributors.md
@@ -10,7 +10,7 @@ This list is incomplete; you can help by
 - [Charles Frye](https://twitter.com/charles_irl) wrote the majority of the
   material and takes full responsibility for any errors.
 - [Matthew Nappo](https://www.linkedin.com/in/mattnappo/) wrote the initial
-  internal "GPU Glossary" document from which this sprung.
+  internal "GPU Glossary" document from which this has sprung.
 - [Harmya Bhatt](https://twitter.com/racerfunction) of
   [Tensara](https://tensara.org/) co-wrote the material on
   [performance](/gpu-glossary/perf).

--- a/gpu-glossary/device-hardware/core.md
+++ b/gpu-glossary/device-hardware/core.md
@@ -12,7 +12,7 @@ Examples of GPU core types include
 [Tensor Cores](/gpu-glossary/device-hardware/tensor-core).
 
 Though GPU cores are comparable to CPU cores in that they are the component that
-effects actual computations, this analogy can be quite misleading. Instead, it
+performs actual computations, this analogy can be quite misleading. Instead, it
 is perhaps more helpful to take the viewpoint of the
 [quantitative computer architect](https://archive.org/details/computerarchitectureaquantitativeapproach6thedition)
 and think of them as "pipes" into which data goes in and out of which

--- a/gpu-glossary/device-hardware/cuda-core.md
+++ b/gpu-glossary/device-hardware/cuda-core.md
@@ -18,7 +18,7 @@ instruction simultaneously by the
 instruction to different [registers](/gpu-glossary/device-software/registers).
 Commonly, these groups are of size 32, the size of a
 [warp](/gpu-glossary/device-software/warp), but for contemporary GPUs groups can
-contain as little as one thread, at a cost to performance.
+contain as few as one thread, at a cost to performance.
 
 The term "CUDA Core" is slightly slippery: in different
 [Streaming Multiprocessor architectures](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
@@ -29,7 +29,7 @@ specialized compute units mapped onto shader pipelines (see
 [CUDA Device Architecture](/gpu-glossary/device-hardware/cuda-device-architecture)).
 
 So, for example, the
-[H100 whitepaper](https://resources.nvidia.com/en-us-hopper-architecture/nvidia-h100-tensor-c)
+[H100 white paper](https://resources.nvidia.com/en-us-hopper-architecture/nvidia-h100-tensor-c)
 indicates that an H100 GPU's
 [Streaming Multiprocessors (SMs)](/gpu-glossary/device-hardware/streaming-multiprocessor)
 each have 128 "FP32 CUDA Cores", which accurately counts the number of 32 bit

--- a/gpu-glossary/device-hardware/cuda-device-architecture.md
+++ b/gpu-glossary/device-hardware/cuda-device-architecture.md
@@ -45,8 +45,7 @@ Sanglard. That blog post cites its (high-quality) sources, like NVIDIA's
 [Fermi Compute Architecture white paper](https://www.nvidia.com/content/pdf/fermi_white_papers/nvidia_fermi_compute_architecture_whitepaper.pdf).
 The white paper by
 [Lindholm et al. in 2008](https://www.cs.cmu.edu/afs/cs/academic/class/15869-f11/www/readings/lindholm08_tesla.pdf)
-introducing the Tesla architecture is both well-written and thorough. The
-[NVIDIA whitepaper for the Tesla P100](https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf)
+introducing the Tesla architecture is both well-written and thorough. The [NVIDIA white paper for the Tesla P100](https://images.nvidia.com/content/pdf/tesla/whitepaper/pascal-architecture-whitepaper.pdf)
 is less scholarly but documents the introduction of a number of features that
 are critical for today's large-scale neural network workloads, like NVLink and
 [on-package high-bandwidth memory](/gpu-glossary/device-hardware/gpu-ram).

--- a/gpu-glossary/device-hardware/gpu-ram.md
+++ b/gpu-glossary/device-hardware/gpu-ram.md
@@ -2,7 +2,7 @@
 title: What is GPU RAM?
 ---
 
-![In high-performance data center GPUs like the H100, RAM is located on a die directly next to the processor's. Adapted from the Wikipedia page for [high-bandwidth memory](https://en.wikipedia.org/wiki/High_Bandwidth_Memory).](themed-image://hbm-schematic.svg)
+![In high-performance data center GPUs like the H100, RAM is located on a die directly next to the processor's die. Adapted from the Wikipedia page for [high-bandwidth memory](https://en.wikipedia.org/wiki/High_Bandwidth_Memory).](themed-image://hbm-schematic.svg)
 
 The bottom-level memory of the GPU is a large (many megabytes to gigabytes)
 memory store that is addressable by all of the GPU's

--- a/gpu-glossary/device-hardware/graphics-processing-cluster.md
+++ b/gpu-glossary/device-hardware/graphics-processing-cluster.md
@@ -23,5 +23,5 @@ scheduled onto the same GPC, just as the threads of a
 [thread block](/gpu-glossary/device-software/thread-block) are scheduled onto
 the same [SM](/gpu-glossary/device-hardware/streaming-multiprocessor), and have
 their own level of the
-[memory hierarchy](/gpu-glossary/device-software/memory-hierarchy), distributed
-shared memory. Elsewhere, we elide discussion of this feature.
+[memory hierarchy](/gpu-glossary/device-software/memory-hierarchy), called
+distributed shared memory. Elsewhere, we elide discussion of this feature.

--- a/gpu-glossary/device-hardware/l1-data-cache.md
+++ b/gpu-glossary/device-hardware/l1-data-cache.md
@@ -13,7 +13,7 @@ Each SM partitions that memory among
 it.
 
 The L1 data cache is co-located with and only about an order of magnitude slower
-than the components that effect computations (e.g. the
+than the components that perform computations (e.g., the
 [CUDA Cores](/gpu-glossary/device-hardware/cuda-core)).
 
 It is implemented with SRAM, the same basic semiconductor cell used in CPU
@@ -24,7 +24,7 @@ The L1 data cache is accessed by the
 [SM](/gpu-glossary/device-hardware/streaming-multiprocessor).
 
 CPUs also maintain an L1 cache. In CPUs, that cache is fully hardware-managed.
-In GPUs that cache is mostly programmer-managed, even in high-level languages
+In GPUs, that cache is mostly programmer-managed, even in high-level languages
 like [CUDA C](/gpu-glossary/host-software/cuda-c).
 
 Each L1 data cache in each of an H100's SMs can store 256 KiB (2,097,152 bits).

--- a/gpu-glossary/device-hardware/load-store-unit.md
+++ b/gpu-glossary/device-hardware/load-store-unit.md
@@ -14,7 +14,7 @@ interact directly with the
 [Streaming Multiprocessor](/gpu-glossary/device-hardware/streaming-multiprocessor)'s
 on-chip SRAM [L1 data cache](/gpu-glossary/device-hardware/l1-data-cache) and
 indirectly with the off-chip, on-device
-[global RAM](/gpu-glossary/device-hardware/gpu-ram) that respectively implement
+[global RAM](/gpu-glossary/device-hardware/gpu-ram), which respectively implement
 the lowest and highest levels of the
 [memory hierarchy](/gpu-glossary/device-software/memory-hierarchy) in the
 [CUDA programming model](/gpu-glossary/device-software/cuda-programming-model).

--- a/gpu-glossary/device-hardware/register-file.md
+++ b/gpu-glossary/device-hardware/register-file.md
@@ -9,7 +9,7 @@ is the primary store of bits in between their manipulation by the
 
 ![The internal architecture of an H100 SM. The register file is depicted in blue. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
 
-Like registers in CPUs, these registers are made from very fast memory
+Like registers in CPUs, these registers are made from extremely fast memory
 technology that can keep pace with the compute
 [cores](/gpu-glossary/device-hardware/core), about an order of magnitude faster
 than the [L1 data cache](/gpu-glossary/device-hardware/l1-data-cache).

--- a/gpu-glossary/device-hardware/tensor-memory-accelerator.md
+++ b/gpu-glossary/device-hardware/tensor-memory-accelerator.md
@@ -39,7 +39,7 @@ asynchronously detect the completion of the TMA copy after it finishes and
 operate on the results (as in a producer-consumer model).
 
 For details, see the TMA sections of
-[Luo et al.'s Hopper micro-benchmarking paper](https://arxiv.org/abs/2501.12084v1).
+[Luo et al.'s Hopper micro-benchmarking paper](https://arxiv.org/abs/2501.12084v1)
 and the
 [NVIDIA Hopper Tuning Guide](https://docs.nvidia.com/cuda/hopper-tuning-guide/index.html#tensor-memory-accelerator).
 

--- a/gpu-glossary/device-hardware/warp-scheduler.md
+++ b/gpu-glossary/device-hardware/warp-scheduler.md
@@ -10,8 +10,8 @@ execute on each clock cycle.
 ![The internal architecture of an H100 SM. The Warp Scheduler and Dispatch Unit are shown in orange. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
 
 These groups of [threads](/gpu-glossary/device-software/thread), known as
-[warps](/gpu-glossary/device-software/warp), are switched out on a per clock
-cycle basis — roughly one nanosecond - much like the fine-grained thread-level
+[warps](/gpu-glossary/device-software/warp), are switched out on a per-clock-cycle
+basis—roughly one nanosecond—much like the fine-grained thread-level
 parallelism of simultaneous multi-threading ("hyper-threading") in CPUs, but at
 a much larger scale. The ability of the Warp Schedulers to switch rapidly
 between a large number of concurrent tasks as soon as their instructions'
@@ -29,7 +29,7 @@ Because each [thread](/gpu-glossary/device-software/thread) has its own private
 [registers](/gpu-glossary/device-software/registers) allocated from the
 [register file](/gpu-glossary/device-hardware/register-file) of the
 [SM](/gpu-glossary/device-hardware/streaming-multiprocessor), context switches
-on the GPU do not require any data movement to save or restore contexts.
+on GPUs do not require any data movement to save or restore contexts.
 
 And because the [L1 caches](/gpu-glossary/device-hardware/l1-data-cache) on GPUs
 can be entirely programmer-managed and are

--- a/gpu-glossary/device-software/parallel-thread-execution.md
+++ b/gpu-glossary/device-software/parallel-thread-execution.md
@@ -100,7 +100,7 @@ version".
 Writing in-line PTX by hand is uncommon outside of the cutting edge of
 performance, similar to writing in-line `x86_64` assembly, as is done in
 high-performance vectorized query operators in analytical databases and in
-performance-sensitive sections of operating system kernels. At time of writing
+performance-sensitive sections of operating system kernels. At the time of writing
 in September of 2025, in-line PTX is the only way to take advantage of some
 Hopper-specific hardware features like the `wgmma` and `tma` instructions, as in
 [Flash Attention 3](https://arxiv.org/abs/2407.08608) or in the

--- a/gpu-glossary/device-software/registers.md
+++ b/gpu-glossary/device-software/registers.md
@@ -21,7 +21,7 @@ As when programming CPUs, these registers are not directly manipulated by
 high-level languages like [CUDA C](/gpu-glossary/host-software/cuda-c). They are
 only visible to a lower-level language, here
 [Parallel Thread Execution (PTX)](/gpu-glossary/device-software/parallel-thread-execution).
-They are typically managed by a compiler like `ptaxs`. Among the compiler's
+They are typically managed by a compiler like `ptxas`. Among the compiler's
 goals is to limit the register space used by each
 [thread](/gpu-glossary/device-software/thread) so that more
 [thread blocks](/gpu-glossary/device-software/thread-block) can be

--- a/gpu-glossary/device-software/thread-hierarchy.md
+++ b/gpu-glossary/device-software/thread-hierarchy.md
@@ -14,7 +14,7 @@ threads up to entire GPU devices.
 At the lowest level are individual
 [threads](/gpu-glossary/device-software/thread). Like a thread of execution on a
 CPU, each [CUDA thread](/gpu-glossary/device-software/thread) executes a stream
-of instructions. The hardware resources that effect arithmetic and logic
+of instructions. The hardware resources that execute arithmetic and logic
 instructions are called [cores](/gpu-glossary/device-hardware/core) or sometimes
 "pipes". Threads are selected for execution by the
 [Warp Scheduler](/gpu-glossary/device-hardware/warp-scheduler).

--- a/gpu-glossary/device-software/warp.md
+++ b/gpu-glossary/device-software/warp.md
@@ -35,7 +35,7 @@ for a table of results per clock cycle for specific instructions).
 A warp whose next instruction is delayed by missing operands is said to be
 [stalled](/gpu-glossary/perf/warp-execution-state).
 
-Instead of waiting for an instructions results to return, when multiple warps
+Instead of waiting for an instruction's results to return, when multiple warps
 are scheduled onto a single
 [SM](/gpu-glossary/device-hardware/streaming-multiprocessor), the
 [Warp Scheduler](/gpu-glossary/device-hardware/warp-scheduler) will select

--- a/gpu-glossary/host-software/cudnn.md
+++ b/gpu-glossary/host-software/cudnn.md
@@ -21,14 +21,14 @@ layers, normalization routines, and attention mechanisms.
 
 In modern cuDNN code, computations are expressed as operation graphs, which can
 be constructed using open source
-[Python and C++ frontend APIs](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/developer/overview.html).
+[Python and C++ frontend APIs](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/developer/overview.html)
 via the declarative
 [Graph API](https://docs.nvidia.com/deeplearning/cudnn/frontend/v1.14.0/developer/graph-api.html).
 
 This API allows the developer to define a sequence of operations as a graph,
 which cuDNN can then analyze to perform optimizations, most importantly
 operation fusion. In operation fusion, a sequence of operations like
-Convolution + Bias + ReLU are merged ("fused") into a single operation run as a
+Convolution + Bias + ReLU is merged ("fused") into a single operation run as a
 single [kernel](/gpu-glossary/device-software/kernel). Operation fusion helps
 reduce demand on [memory bandwidth](/gpu-glossary/perf/memory-bandwidth) by
 keeping program intermediates in

--- a/gpu-glossary/host-software/nsight-systems.md
+++ b/gpu-glossary/host-software/nsight-systems.md
@@ -6,8 +6,8 @@ NVIDIA Nsight Systems is a performance debugging tool for
 [CUDA C++](/gpu-glossary/host-software/cuda-c) programs. It combines profiling,
 tracing, and expert systems analysis in a GUI.
 
-No one wakes up and says "today I want to write a program that runs on a hard to
-use, expensive piece of hardware using a proprietary software stack". Instead,
+No one wakes up and says "today I want to write a program that runs on a hard-to-use,
+expensive piece of hardware using a proprietary software stack". Instead,
 GPUs are selected when normal computing hardware doesn't perform well enough to
 solve a computing problem. So
 [almost all GPU programs are performance-sensitive](/gpu-glossary/perf), and the

--- a/gpu-glossary/host-software/nvml.md
+++ b/gpu-glossary/host-software/nvml.md
@@ -10,7 +10,7 @@ state. For details on these metrics, including how to interpret power and
 thermal readings, see
 [this page on the Modal docs](https://modal.com/docs/guide/gpu-metrics).
 
-The function of NVML are frequently accessed via the
+The functions of NVML are frequently accessed via the
 [nvidia-smi](/gpu-glossary/host-software/nvidia-smi) command line utility, but
 are also accessible to programs via wrappers, like
 [pynvml in Python](https://pypi.org/project/pynvml/) and

--- a/gpu-glossary/perf.md
+++ b/gpu-glossary/perf.md
@@ -11,7 +11,7 @@ web server, correctness is the primary concern. If the application loses data or
 returns incorrect results, then the application has failed. Performance is often
 ignored.
 
-When programming GPUs, correctness is typically poorly-defined. "Correct"
+When programming GPUs, correctness is typically poorly defined. "Correct"
 outputs are defined only up to some number of significant bits or only for some
 underdetermined subset of "well-behaved" inputs. And correctness is at best
 necessary but not sufficient. If the programmers of the application cannot

--- a/gpu-glossary/perf/arithmetic-bandwidth.md
+++ b/gpu-glossary/perf/arithmetic-bandwidth.md
@@ -42,7 +42,7 @@ nine PFLOPS when running 4-bit floating point matrix multiplications.
 
 Representative bandwidth numbers for NVIDIA data center GPUs between the Ampere
 and Blackwell
-[Streaming Multiprocessor architecures](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
+[Streaming Multiprocessor architectures](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
 are listed in the table below.
 
 | **System (Compute / Memory)**                                                                                                                               | **Arithmetic Bandwidth (TFLOPs/s)** | **[Memory Bandwidth](/gpu-glossary/perf/memory-bandwidth) (TB/s)** | **[Ridge Point](/gpu-glossary/perf/roofline-model) (FLOPs/byte)** |

--- a/gpu-glossary/perf/arithmetic-intensity.md
+++ b/gpu-glossary/perf/arithmetic-intensity.md
@@ -12,7 +12,7 @@ A high arithmetic intensity indicates that a
 operations per byte loaded. Due to the high ratio between
 [arithmetic bandwidth](/gpu-glossary/perf/arithmetic-bandwidth) and
 [memory bandwidth](/gpu-glossary/perf/memory-bandwidth) in modern GPUs, the most
-efficient kernels have high arithmetic intensity. That means that when elevating
+efficient kernels have high arithmetic intensity. This means that when alleviating
 a memory [bottleneck](/gpu-glossary/perf/performance-bottleneck), we can often
 shift work from the memory subsystem to the compute subsystem, saving on
 [memory bandwidth](/gpu-glossary/perf/memory-bandwidth) but adding to the load
@@ -28,7 +28,7 @@ increasing the arithmetic intensity.
 
 As another example, the
 [backpropagation algorithm](https://www.nature.com/articles/323533a0) creates
-long-lived intermediates (activation values) that generally must stored in
+long-lived intermediates (activation values) that generally must be stored in
 [global memory](/gpu-glossary/device-software/global-memory) during a forward
 pass and then retrieved during a backwards pass. In some cases, it is faster to
 store only a fraction of these intermediates and then recompute the remainder (a

--- a/gpu-glossary/perf/bank-conflict.md
+++ b/gpu-glossary/perf/bank-conflict.md
@@ -60,7 +60,7 @@ elements per row, and so we wrote:
 
 ```cpp
 float value = data[tid * 32];  // address LSBs: 0x000, 0x080, 0x100 ...
-// recall: floats are 4 bits wide
+// recall: floats are 4 bytes wide
 ```
 
 As depicted in the right side of the diagram above, all accesses hit the same

--- a/gpu-glossary/perf/memory-bandwidth.md
+++ b/gpu-glossary/perf/memory-bandwidth.md
@@ -20,8 +20,8 @@ The most important bandwidth is that between the
 because the [working sets](https://en.wikipedia.org/wiki/Working_set_size) of
 most [kernels](/gpu-glossary/device-software/kernel) only fit in
 [GPU RAM](/gpu-glossary/device-software/memory-hierarchy), not anywhere higher
-up in the [memory hierarchy](/gpu-glossary/device-software/memory-hierarchy). It
-is for this reason that that bandwidth is the primary one used in
+up in the [memory hierarchy](/gpu-glossary/device-software/memory-hierarchy).
+For this reason, that bandwidth is the primary one used in
 [roofline modeling](/gpu-glossary/perf/roofline-model) of GPU
 [kernel](/gpu-glossary/device-software/kernel) performance.
 
@@ -35,7 +35,7 @@ leading to increased [ridge point](/gpu-glossary/perf/roofline-model)
 
 Representative bandwidth numbers for NVIDIA data center GPUs between the Ampere
 and Blackwell
-[Streaming Multiprocessor architecures](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
+[Streaming Multiprocessor architectures](/gpu-glossary/device-hardware/streaming-multiprocessor-architecture)
 are listed in the table below.
 
 | **System (Compute / Memory)**                                                                                                                               | **[Arithmetic Bandwidth](/gpu-glossary/perf/arithmetic-bandwidth) (TFLOPs/s)** | **Memory Bandwidth (TB/s)** | **[Ridge Point](/gpu-glossary/perf/roofline-model) (FLOPs/byte)** |

--- a/gpu-glossary/perf/memory-bound.md
+++ b/gpu-glossary/perf/memory-bound.md
@@ -6,7 +6,7 @@ title: What does it mean to be memory-bound?
 limited by the [memory bandwidth](/gpu-glossary/perf/memory-bandwidth) of the
 GPU.
 
-![Roofline diagrams, like the one above, help identify whether a program's performance is bottlenecked by compute power, memory bandwidth, or something else Diagram adapted from [Williams, Waterman, and Patterson (2008)](https://people.eecs.berkeley.edu/~kubitron/cs252/handouts/papers/RooflineVyNoYellow.pdf).](themed-image://roofline-model.svg)
+![Roofline diagrams, like the one above, help identify whether a program's performance is bottlenecked by compute power, memory bandwidth, or something else. Diagram adapted from [Williams, Waterman, and Patterson (2008)](https://people.eecs.berkeley.edu/~kubitron/cs252/handouts/papers/RooflineVyNoYellow.pdf).](themed-image://roofline-model.svg)
 
 Specifically, they are limited by
 [the bandwidth](/gpu-glossary/perf/memory-bandwidth) between the
@@ -33,17 +33,17 @@ Contemporary large language model inference workloads are often memory-bound
 during the decode/output generation stage, when the weights must be loaded once
 in each forward pass. That happens once per output token, unless multi-token
 prediction or speculative decoding are used, which makes it easy to calculate
-the minimum latency between tokens (intertoken latency or time per output token)
+the minimum latency between tokens (inter-token latency or time per output token)
 for memory-bound Transformer large language model inference.
 
 Assume the model has 500B parameters, stored in 16-bit precision, for a total of
 1 TB. If we run inference on a single GPU with a
 [memory bandwidth](/gpu-glossary/perf/memory-bandwidth) of 10 TB/s, we can load
-the weights once every 100 ms, and that puts a lower bound on our intertoken
+the weights once every 100 ms, and that puts a lower bound on our inter-token
 latency. By batching multiple inputs together, we can linearly increase the
 number of floating point operations done per parameter loaded (the
 [arithmetic intensity](/gpu-glossary/perf/arithmetic-intensity)), in principle
-up the point of [compute-boundedness](/gpu-glossary/perf/compute-bound), without
+up to the point of [compute-boundedness](/gpu-glossary/perf/compute-bound), without
 incurring any additional latency, which implies that the throughput improves
 linearly in the batch size.
 

--- a/gpu-glossary/perf/peak-rate.md
+++ b/gpu-glossary/perf/peak-rate.md
@@ -36,4 +36,4 @@ The H100 can operate its compute subsystem clock at a maximum rate of 1980 MHz
 66,908 billion FLOPS, or 66.9 TFLOPS.
 
 This precisely matches the Peak FP32 TFLOPS (non-Tensor) rate advertised in
-[NVIDIA's H100 whitepaper](https://resources.nvidia.com/en-us-hopper-architecture/nvidia-h100-tensor-c).
+[NVIDIA's H100 white paper](https://resources.nvidia.com/en-us-hopper-architecture/nvidia-h100-tensor-c).

--- a/gpu-glossary/perf/pipe-utilization.md
+++ b/gpu-glossary/perf/pipe-utilization.md
@@ -23,7 +23,7 @@ programmers should first consider
 [GPU kernel utilization](https://modal.com/blog/gpu-utilization-guide) and
 [SM utilization](/gpu-glossary/perf/streaming-multiprocessor-utilization).
 
-Pipe utilization is available in the the
+Pipe utilization is available in the
 `sm__inst_executed_pipe_*.avg.pct_of_peak_sustained_active` metrics from
 [NSight Compute](https://developer.nvidia.com/nsight-compute) (`ncu`), where the
 asterisk represents specific pipelines like

--- a/gpu-glossary/perf/roofline-model.md
+++ b/gpu-glossary/perf/roofline-model.md
@@ -84,8 +84,8 @@ Finally, the early 2000s saw the end of
 [Dennard scaling](https://en.wikipedia.org/wiki/Dennard_scaling), aka increasing
 clock speed at equal power, due primarily to the fixed leakage current of
 transistors, which posed power draw and heat dissipation problems. Increasing
-clock speed had previously buoyed general purpose, latency-oriented systems like
-CPUs, over special purpose hardware. This slowdown was not accompanied by a
+clock speed had previously buoyed general-purpose, latency-oriented systems like
+CPUs, over special-purpose hardware. This slowdown was not accompanied by a
 slowdown in [Moore's Law](https://en.wikipedia.org/wiki/Moore%27s_law), aka
 increasing transistor count per chip. The architectural solution to an abundance
 of transistors but scarcity of power was hardware specialization: disaggregating


### PR DESCRIPTION
Hi, made a few fixes -

- Fixes spelling mistakes, duplicated words, grammar, and punctuation slips across 25+ glossary entries (hardware, software, and performance sections). E.g., `ptaxs` -> `ptxas`, `little` -> `few`
- Refines phrasing with more precise word choices. E.g., `effect` -> `execute`, `very` -> `extremely`

Docs-only changes.

For reviewers -
- Changes are split into two commits: one for straightforward typo fixes, one for phrasing/clarity tweaks.
- No front-matter or metadata was altered; only markdown content was touched.

There’s more cleanup to do, but I kept the scope modest to avoid touching every single file.