### PR TITLE
switch to a Modal-hosted version of the H100 white paper

### DIFF
--- a/gpu-glossary/device-hardware/core.md
+++ b/gpu-glossary/device-hardware/core.md
@@ -5,7 +5,7 @@ title: What is a GPU Core?
 The cores are the primary compute units that make up the
 [Streaming Multiprocessors (SMs)](/gpu-glossary/device-hardware/streaming-multiprocessor).
 
-![The internal architecture of an H100 GPU's Streaming Multiprocessors. CUDA and Tensor Cores are shown in green. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 GPU's Streaming Multiprocessors. CUDA and Tensor Cores are shown in green. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Examples of GPU core types include
 [CUDA Cores](/gpu-glossary/device-hardware/cuda-core) and

--- a/gpu-glossary/device-hardware/cuda-core.md
+++ b/gpu-glossary/device-hardware/cuda-core.md
@@ -5,7 +5,7 @@ title: What is a CUDA Core?
 The CUDA Cores are GPU [cores](/gpu-glossary/device-hardware/core) that execute
 scalar arithmetic instructions.
 
-![The internal architecture of an H100 SM. The CUDA Cores and Tensor Cores are depicted in green. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. The CUDA Cores and Tensor Cores are depicted in green. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 They are to be contrasted with the
 [Tensor Cores](/gpu-glossary/device-hardware/tensor-core), which execute matrix

--- a/gpu-glossary/device-hardware/l1-data-cache.md
+++ b/gpu-glossary/device-hardware/l1-data-cache.md
@@ -6,7 +6,7 @@ The L1 data cache is the private memory of the
 [Streaming Multiprocessor](/gpu-glossary/device-hardware/streaming-multiprocessor)
 (SM).
 
-![The internal architecture of an H100 SM. The L1 data cache is depicted in light blue. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. The L1 data cache is depicted in light blue. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Each SM partitions that memory among
 [groups of threads](/gpu-glossary/device-software/thread-block) scheduled onto

--- a/gpu-glossary/device-hardware/load-store-unit.md
+++ b/gpu-glossary/device-hardware/load-store-unit.md
@@ -6,7 +6,7 @@ abbreviation: LSU
 The Load/Store Units (LSUs) dispatch requests to load or store data to the
 memory subsystems of the GPU.
 
-![The internal architecture of an H100 SM. Load/Store Units are shown in pink, along with the [Special Function Units](/gpu-glossary/device-hardware/special-function-unit). Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. Load/Store Units are shown in pink, along with the [Special Function Units](/gpu-glossary/device-hardware/special-function-unit). Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Most importantly for
 [CUDA programmers](/gpu-glossary/host-software/cuda-software-platform), they

--- a/gpu-glossary/device-hardware/register-file.md
+++ b/gpu-glossary/device-hardware/register-file.md
@@ -7,7 +7,7 @@ The register file of the
 is the primary store of bits in between their manipulation by the
 [cores](/gpu-glossary/device-hardware/core).
 
-![The internal architecture of an H100 SM. The register file is depicted in blue. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. The register file is depicted in blue. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Like registers in CPUs, these registers are made from very fast memory
 technology that can keep pace with the compute

--- a/gpu-glossary/device-hardware/special-function-unit.md
+++ b/gpu-glossary/device-hardware/special-function-unit.md
@@ -7,7 +7,7 @@ The Special Function Units (SFUs) in
 [Streaming Multiprocessors (SMs)](/gpu-glossary/device-hardware/streaming-multiprocessor)
 accelerate certain arithmetic operations.
 
-![The internal architecture of an H100 SM. Special Function Units are shown in maroon, along with the [Load/Store Units](/gpu-glossary/device-hardware/load-store-unit). Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. Special Function Units are shown in maroon, along with the [Load/Store Units](/gpu-glossary/device-hardware/load-store-unit). Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Notable for neural network workloads are transcendental mathematical operations,
 like `exp`, `sin`, and `cos`.

--- a/gpu-glossary/device-hardware/streaming-multiprocessor-architecture.md
+++ b/gpu-glossary/device-hardware/streaming-multiprocessor-architecture.md
@@ -8,7 +8,7 @@ with
 [Streaming Assembler (SASS)](/gpu-glossary/device-software/streaming-assembler)
 code.
 
-![A streaming multiprocessor with the "Hopper" SM90 architecture. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![A streaming multiprocessor with the "Hopper" SM90 architecture. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 ![A streaming multiprocessor with the original "Tesla" SM architecture. Modified from [Fabien Sanglard's blog](https://fabiensanglard.net/cuda)](themed-image://tesla-sm.svg)
 

--- a/gpu-glossary/device-hardware/streaming-multiprocessor.md
+++ b/gpu-glossary/device-hardware/streaming-multiprocessor.md
@@ -8,7 +8,7 @@ produce
 [sequences of instructions](/gpu-glossary/device-software/streaming-assembler)
 for its Streaming Multiprocessors to carry out.
 
-![A diagram of the internal architecture of an H100 GPU's Streaming Multiprocessors. GPU cores appear in green, other compute units in maroon, scheduling units in orange, and memory in blue. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![A diagram of the internal architecture of an H100 GPU's Streaming Multiprocessors. GPU cores appear in green, other compute units in maroon, scheduling units in orange, and memory in blue. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Streaming Multiprocessors (SMs) of NVIDIA GPUs are roughly analogous to the
 cores of CPUs. That is, SMs both execute computations and store state available

--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -5,7 +5,7 @@ title: What is a Tensor Core?
 Tensor Cores are GPU [cores](/gpu-glossary/device-hardware/core) that operate on
 entire matrices with each instruction.
 
-![The internal architecture of an H100 SM. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. Note the larger size and lower number of Tensor Cores. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 Operating on more data for a single instruction fetch dramatically reduces power
 requirements, which unlocks increased performance (see

--- a/gpu-glossary/device-hardware/tensor-memory-accelerator.md
+++ b/gpu-glossary/device-hardware/tensor-memory-accelerator.md
@@ -8,7 +8,7 @@ Tensor Memory Accelerators are specialized hardware in Hopper and Blackwell
 GPUs designed to accelerate access to multi-dimensional arrays in
 [GPU RAM](/gpu-glossary/device-hardware/gpu-ram).
 
-![The internal architecture of an H100 [Streaming Multiprocessor (SM)](/gpu-glossary/device-hardware/streaming-multiprocessor). Note the Tensor Memory Accelerator at the bottom of the [SM](/gpu-glossary/device-hardware/streaming-multiprocessor), shared between the four sub-units. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 [Streaming Multiprocessor (SM)](/gpu-glossary/device-hardware/streaming-multiprocessor). Note the Tensor Memory Accelerator at the bottom of the [SM](/gpu-glossary/device-hardware/streaming-multiprocessor), shared between the four sub-units. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 The TMA loads data from
 [global memory](/gpu-glossary/device-software/global-memory)/[GPU RAM](/gpu-glossary/device-hardware/gpu-ram)

--- a/gpu-glossary/device-hardware/warp-scheduler.md
+++ b/gpu-glossary/device-hardware/warp-scheduler.md
@@ -7,7 +7,7 @@ The Warp Scheduler of the
 decides which group of [threads](/gpu-glossary/device-software/thread) to
 execute on each clock cycle.
 
-![The internal architecture of an H100 SM. The Warp Scheduler and Dispatch Unit are shown in orange. Modified from NVIDIA's [H100 white paper](https://resources.nvidia.com/en-us-tensor-core).](themed-image://gh100-sm.svg)
+![The internal architecture of an H100 SM. The Warp Scheduler and Dispatch Unit are shown in orange. Modified from NVIDIA's [H100 white paper](https://modal-cdn.com/gpu-glossary/gtc22-whitepaper-hopper.pdf).](themed-image://gh100-sm.svg)
 
 These groups of [threads](/gpu-glossary/device-software/thread), known as
 [warps](/gpu-glossary/device-software/warp), are switched out on a per clock


### PR DESCRIPTION
Link is broken, as reported in #64.

NVIDIA has moved this one around on us multiple times, so let's just host it ourselves.