### PR TITLE
Correct description of HMMA16 matrix dimensions

### DIFF
--- a/gpu-glossary/device-hardware/tensor-core.md
+++ b/gpu-glossary/device-hardware/tensor-core.md
@@ -24,14 +24,14 @@ matrix as D). The `MMA` stands for "Matrix Multiply and Accumulate". `HMMA16`
 indicates that the inputs are half-precision (`16` bits) and the `F32` indicates
 that the outputs are accumulated into `32` bit (aka single-precision) floats.
 
-`16816` is not a single number larger than 16,000. Instead, the string of
-numbers `16`, `8`, `16` denote the dimensions of the matrices. These dimensions
-are generally named `m`, `k`, and `n` by NVIDIA, for example in
-[PTX](/gpu-glossary/device-software/parallel-thread-execution) instructions. The
-outer dimensions of A and B, aka `m` and `n`, come first and last, respectively,
-and the shared inner dimension for the accumulation, `k`, is in the middle.
-Multiplying these out, we see that the `HMMA16.16816.32` instruction performs 16
-× 8 × 16 = 2,048 multiply-accumulate (MAC) operations.
+`16816` isn’t a single number greater than 16,000. Instead, it abbreviates
+the matrix dimensions `16`, `8`, and `16`. NVIDIA typically denotes these as
+`m`, `n`, and `k`
+(e.g., in [PTX](/gpu-glossary/device-software/parallel-thread-execution) instructions).
+The outer dimensions of A and B, `m` and `n`, come first, followed by the shared
+inner accumulation dimension, `k`. Multiplying them gives `16 × 8 × 16 = 2,048`,
+so the `HMMA16.16816.32` instruction performs 2,048 multiply–accumulate (MAC)
+operations.
 
 Note that a single instruction in a single
 [thread](/gpu-glossary/device-software/thread) does not produce the entire


### PR DESCRIPTION
Correct the explanation of the '16816' matrix dimensions and their relation to the HMMA16 instruction.

In relation to issue #70 