### PR TITLE
"[CUDA] C++" not "[CUDA] C/C++"

### DIFF
--- a/gpu-glossary/device-hardware/graphics-processing-cluster.md
+++ b/gpu-glossary/device-hardware/graphics-processing-cluster.md
@@ -9,7 +9,7 @@ A GPC is a collection of
 [Streaming Multiprocessors](/gpu-glossary/device-hardware/streaming-multiprocessor)
 or SMs) plus a raster engine. Apparently, some people use NVIDIA GPUs for
 graphics, for which the raster engine is important. Relatedly, the name used to
-stand for Graphics Processing Cluster, but is now, e.g. in the
+stand for Graphics Processing Cluster, but is now, e.g., in the
 [NVIDIA CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html),
 expanded as "GPU Processing Cluster".
 

--- a/gpu-glossary/device-hardware/l1-data-cache.md
+++ b/gpu-glossary/device-hardware/l1-data-cache.md
@@ -25,7 +25,7 @@ The L1 data cache is accessed by the
 
 CPUs also maintain an L1 cache. In CPUs, that cache is fully hardware-managed.
 In GPUs that cache is mostly programmer-managed, even in high-level languages
-like [CUDA C](/gpu-glossary/host-software/cuda-c).
+like [CUDA C++](/gpu-glossary/host-software/cuda-c).
 
 Each L1 data cache in each of an H100's SMs can store 256 KiB (2,097,152 bits).
 Across the 132 SMs in an H100 SXM 5, that's 33 MiB (242,221,056 bits) of cache

--- a/gpu-glossary/device-hardware/streaming-multiprocessor.md
+++ b/gpu-glossary/device-hardware/streaming-multiprocessor.md
@@ -60,7 +60,7 @@ maintaining large, hardware-managed caches and sophisticated instruction
 prediction. This extra hardware limits the fraction of their silicon area,
 power, and heat budgets that CPUs can allocate to computation.
 
-![GPUs dedicate more of their area to compute (green), and less to control and caching (orange and blue), than do CPUs. Modified from a diagram in [Fabien Sanglard's blog](https://fabiensanglard.net/cuda), itself likely modified from a diagram in [the CUDA C Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).](themed-image://cpu-vs-gpu.svg)
+![GPUs dedicate more of their area to compute (green), and less to control and caching (orange and blue), than do CPUs. Modified from a diagram in [Fabien Sanglard's blog](https://fabiensanglard.net/cuda), itself likely modified from a diagram in [the CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/).](themed-image://cpu-vs-gpu.svg)
 
 For programs or functions like neural network inference or sequential database
 scans for which it is relatively straightforward for programmers to

--- a/gpu-glossary/device-hardware/warp-scheduler.md
+++ b/gpu-glossary/device-hardware/warp-scheduler.md
@@ -40,7 +40,7 @@ can be entirely programmer-managed and are
 context switches on the GPU have much less impact on cache hit rates. For
 details on the interaction between programmer-managed caches and
 hardware-managed caches in GPUs, see
-[the "Maximize Memory Throughput" section of the CUDA C Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#maximize-memory-throughput).
+[the "Maximize Memory Throughput" section of the CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#maximize-memory-throughput).
 
 The Warp Schedulers also manage the
 [execution state of warps](/gpu-glossary/perf/warp-execution-state).

--- a/gpu-glossary/device-software/compute-capability.md
+++ b/gpu-glossary/device-software/compute-capability.md
@@ -40,4 +40,4 @@ version.
 
 The technical specifications for each compute capability version can be found in
 the
-[Compute Capability section of the NVIDIA CUDA C Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html).
+[Compute Capability section of the NVIDIA CUDA C++ Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html).

--- a/gpu-glossary/device-software/global-memory.md
+++ b/gpu-glossary/device-software/global-memory.md
@@ -32,7 +32,7 @@ allocated from the host using a memory allocator provided by the
 [CUDA Runtime API](/gpu-glossary/host-software/cuda-runtime-api).
 
 The terminology "global" unfortunately collides with the `__global__` keyword in
-[CUDA C/C++](/gpu-glossary/host-software/cuda-c), which annotates functions that
+[CUDA C++](/gpu-glossary/host-software/cuda-c), which annotates functions that
 are launched on the host but run on the device
 ([kernels](/gpu-glossary/device-software/kernel)), whereas global memory is only
 on the device. Early CUDA architect Nicholas Wilt wrily notes that this choice

--- a/gpu-glossary/device-software/parallel-thread-execution.md
+++ b/gpu-glossary/device-software/parallel-thread-execution.md
@@ -105,7 +105,7 @@ in September of 2025, in-line PTX is the only way to take advantage of some
 Hopper-specific hardware features like the `wgmma` and `tma` instructions, as in
 [Flash Attention 3](https://arxiv.org/abs/2407.08608) or in the
 [Machete w4a16 kernels](https://youtu.be/-4ZkpQ7agXM). Viewing
-[CUDA C/C++](/gpu-glossary/host-software/cuda-c),
+[CUDA C++](/gpu-glossary/host-software/cuda-c),
 [SASS](/gpu-glossary/device-software/streaming-assembler), and
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) together is
 supported on [Godbolt](https://godbolt.org/z/5r9ej3zjW). See the

--- a/gpu-glossary/device-software/registers.md
+++ b/gpu-glossary/device-software/registers.md
@@ -18,7 +18,7 @@ but they can also spill to the
 penalty.
 
 As when programming CPUs, these registers are not directly manipulated by
-high-level languages like [CUDA C](/gpu-glossary/host-software/cuda-c). They are
+high-level languages like [CUDA C++](/gpu-glossary/host-software/cuda-c). They are
 only visible to a lower-level language, here
 [Parallel Thread Execution (PTX)](/gpu-glossary/device-software/parallel-thread-execution).
 They are typically managed by a compiler like `ptxas`. Among the compiler's

--- a/gpu-glossary/device-software/streaming-assembler.md
+++ b/gpu-glossary/device-software/streaming-assembler.md
@@ -29,11 +29,11 @@ Some exemplary instructions in SASS for the SM90a architecture of Hopper GPUs:
 
 Even more so than for CPUs, writing this "GPU assembler" by hand is very
 uncommon. Viewing compiler-generated SASS while profiling and editing high-level
-[CUDA C/C++](/gpu-glossary/host-software/cuda-c) code or in-line
+[CUDA C++](/gpu-glossary/host-software/cuda-c) code or in-line
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) is
 [more common](https://docs.nvidia.com/gameworks/content/developertools/desktop/ptx_sass_assembly_debugging.htm),
 especially in the production of the highest-performance kernels. Viewing
-[CUDA C/C++](/gpu-glossary/host-software/cuda-c), SASS, and
+[CUDA C++](/gpu-glossary/host-software/cuda-c), SASS, and
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) together is
 supported on [Godbolt](https://godbolt.org/z/5r9ej3zjW). For more detail on SASS
 with a focus on performance debugging workflows, see

--- a/gpu-glossary/host-software/cuda-c.md
+++ b/gpu-glossary/host-software/cuda-c.md
@@ -26,7 +26,7 @@ including:
   **[thread](/gpu-glossary/device-software/thread) indexing** with the
   `blockDim` and `threadIdx` built-in variables.
 
-CUDA C++ programs are compiled by a combination of host C/C++ compiler drivers
+CUDA C++ programs are compiled by a combination of host C++ compiler drivers
 like `gcc` and the
 [NVIDIA CUDA Compiler Driver](/gpu-glossary/host-software/nvcc), `nvcc`.
 

--- a/gpu-glossary/host-software/cuda-driver-api.md
+++ b/gpu-glossary/host-software/cuda-driver-api.md
@@ -25,9 +25,9 @@ versions of the CUDA Driver API can run on systems with newer versions of the
 CUDA Driver API. That is, the operating system's binary loader may load a newer
 version of the CUDA Driver API and the program will function the same.
 
-For details on distributing [CUDA C/C++](/gpu-glossary/host-software/cuda-c)
+For details on distributing [CUDA C++](/gpu-glossary/host-software/cuda-c)
 applications, see the
-[CUDA C/C++ Best Practices Guide](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide)
+[CUDA C++ Best Practices Guide](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide)
 from NVIDIA.
 
 The CUDA Driver API is closed source. You can find its documentation

--- a/gpu-glossary/host-software/nvcc.md
+++ b/gpu-glossary/host-software/nvcc.md
@@ -4,7 +4,7 @@ abbreviation: nvcc
 ---
 
 The NVIDIA CUDA Compiler Driver is a toolchain for compiling
-[CUDA C/C++](/gpu-glossary/host-software/cuda-c) programs. It outputs binary
+[CUDA C++](/gpu-glossary/host-software/cuda-c) programs. It outputs binary
 executables that conform to the host ABI and include
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) and/or
 [SASS](/gpu-glossary/device-software/streaming-assembler) to be executed on the

--- a/gpu-glossary/host-software/nvrtc.md
+++ b/gpu-glossary/host-software/nvrtc.md
@@ -4,12 +4,12 @@ abbreviation: nvrtc
 ---
 
 The NVIDIA Runtime Compiler (`nvrtc`) is a runtime compilation library for CUDA
-C. It compiles [CUDA C++](/gpu-glossary/host-software/cuda-c) to
+C++. It compiles [CUDA C++](/gpu-glossary/host-software/cuda-c) to
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) without requiring
 a separate launch of the
 [NVIDIA CUDA Compiler Driver](/gpu-glossary/host-software/nvcc) (`nvcc`) in
 another process. It is used by some libraries or frameworks to, for example, map
-generated C/C++ code to
+generated C++ code to
 [PTX](/gpu-glossary/device-software/parallel-thread-execution) code that can run
 on a GPU.
 


### PR DESCRIPTION
* Replace "CUDA C" or "CUDA C/C++" with "CUDA C++"

* Replace "C/C++" with "C++"

Justification:

1. CUDA C++ is a C++ dialect, as explained in [Section 6 of the "CUDA C++ Programming Guide."](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programming-interface)

2. "C/C++" does not exist, because C is not a subset of C++.

C has syntax that is not valid C++ syntax (e.g., C's `_Generic`). In some cases, the two languages have different semantics for the same syntax.  C and C++ should each be respected as separate languages, each with its own syntax, semantics, international standard, governing body, and idioms.

This commit leaves only one instance of "C/C++," namely in the title of a blog post, ["How to Access Global Memory Efficiently in CUDA C/C++ Kernels."](https://developer.nvidia.com/blog/how-access-global-memory-efficiently-cuda-c-kernels/)

This commit also retains "CUDA C" in a book title: "Professional CUDA C Programming Guide."