### PR TITLE
Fix the Bytes Moved for SGEMM in the arithmetic-intensity

### DIFF
--- a/gpu-glossary/perf/arithmetic-intensity.md
+++ b/gpu-glossary/perf/arithmetic-intensity.md
@@ -45,7 +45,7 @@ O(1) memory complexity has O(N) arithmetic intensity scaling.
 | :------------------------ | -----------: | --------------: | -----------------------: | -------------------------------: |
 | SAXPY y = ax + y          |           2N |             12N |                      1/6 |                             O(1) |
 | Single-Precision Real FFT | 5/2 N log(N) |             16N |              5/32 log(N) |                        O(log(N)) |
-| SGEMM C = A @ B + C       |         2N^3 |           16N^2 |                     N/8  |                             O(N) |
+| SGEMM C = A @ B + C       |         2N^3 |           16N^2 |                      N/8 |                             O(N) |
 
 Notably, matrix multiplication scales linearly, i.e. is O(N), in arithmetic
 intensity — it is O(N^3) in operational complexity and O(N^2) in memory


### PR DESCRIPTION
Hi @charlesfrye, I think the Bytes Moved for SGEMM should be 24N^2 instead of 6N^2.

1. the three matrices A, B, and C each have N^2 elements.

2. In single-precision, each element occupies 4 bytes.