### PR TITLE
fix scoreboard stall explanations

### DIFF
--- a/gpu-glossary/perf/scoreboard-stall.md
+++ b/gpu-glossary/perf/scoreboard-stall.md
@@ -17,25 +17,32 @@ long scoreboard stalls.
 A short scoreboard stall occurs when an instruction is waiting on the result of
 a variable latency instruction which does not leave the
 [Streaming Multiprocessor (SM)](/gpu-glossary/device-hardware/streaming-multiprocessor).
-This includes slow math instructions on the
-[Special Function Unit](/gpu-glossary/device-hardware/special-function-unit)
-like `MUFU.EX2` and `MUFU.SQRT` and matrix multiplications on the
-[Tensor Core](/gpu-glossary/device-hardware/tensor-core) like `MMA`. It also
-includes [shared memory](/gpu-glossary/device-software/shared-memory) operations
-like `LDS` and `STS`.
+Most prominently, this includes
+[shared memory](/gpu-glossary/device-software/shared-memory) operations like
+`LDS` and `STS`, which can have variable latency due to, for instance,
+[bank conflicts](/gpu-glossary/perf/bank-conflict). It also includes certain
+[Special Function Unit (SFU)](/gpu-glossary/device-hardware/special-function-unit)
+operations,
+[reportedly](https://stackoverflow.com/questions/66123750/what-are-the-long-and-short-scoreboards-w-r-t-mio-l1tex)
+because they are shared by
+[SM](/gpu-glossary/device-hardware/streaming-multiprocessor) sub-partitions and
+managed by the same Memory Input/Output hardware as
+[shared memory](/gpu-glossary/device-software/shared-memory) accesses.
 
 A long scoreboard stall occurs when an instruction is waiting on the result of a
-memory operation that leaves the
-[SM](/gpu-glossary/device-hardware/streaming-multiprocessor), such as global
-memory loads (`LDG`) or stores (`STG`). Long scoreboard stalls dominate
+memory operation which may leave the
+[SM](/gpu-glossary/device-hardware/streaming-multiprocessor), such as
+[global memory](/gpu-glossary/device-software/global-memory) loads (`LDG`) or
+stores (`STG`). Long scoreboard stalls dominate
 [memory-bound](/gpu-glossary/perf/memory-bound) code.
-
-A [warp](/gpu-glossary/device-software/warp) has 6 scoreboards which the
-compiler uses to track data dependencies between instructions.
 
 Some scoreboard information is legible in
 [Streaming Assembler (SASS)](/gpu-glossary/device-software/streaming-assembler).
-For example, below is what you might see from a `cuobjdump` with the
+For instance, you can see that each [warp](/gpu-glossary/device-software/warp)
+has six distinct barrier identifiers which the compiler uses to track data
+dependencies between instructions.
+
+Concretely, below is what you might see from a `cuobjdump` with the
 `--dump-sass` flag:
 
 ```nasm

--- a/gpu-glossary/perf/warp-execution-state.md
+++ b/gpu-glossary/perf/warp-execution-state.md
@@ -65,10 +65,11 @@ including:
   operations,
 - pipeline conflicts, i.e. the execution resources are currently occupied.
 
-When warps are stalled on accesses to shared memory or on long-running
-arithmetic instructions, they are said to be stalled on the "short scoreboard".
-When warps are stalled on accesses to GPU RAM, they are said to be stalled on
-the "long scoreboard". Both types of stalls are known as
+When warps are stalled on variable-latency instructions that don't leave the
+[SM](/gpu-glossary/device-hardware/streaming-multiprocessor), they are said to
+be stalled on the "short scoreboard". When warps are stalled on variable-latency
+instructions which do, they are said to be stalled on the "long scoreboard".
+Both types of stalls are known as
 [scoreboard stalls](/gpu-glossary/perf/scoreboard-stall).
 
 Stalled [warps](/gpu-glossary/device-software/warp) appear in multiple slots in


### PR DESCRIPTION
As noted in #94, Tensor Core MMA instructions have fixed execution latency, so saying they are "variable latency instructions" in `scoreboard-stall` isn't obviously right, and I can't find any evidence of them showing up under `stall_short_scoreboard`.

I went on a bit of an odyssey here to try to understand what _actually_ causes something to show up on `stall_short_scoreboard`. The best answer I can come up with is that anything that stalls on a dependency managed by the MIO is logged as a short scoreboard stall and that the MIO is used for the MUFU pipes ([source](https://stackoverflow.com/questions/66123750/what-are-the-long-and-short-scoreboards-w-r-t-mio-l1tex)).

My understanding of this is as follows. It may be buggy! I unfortunately don't have the time to microbenchmark this to get to a final answer. Instead, I'm here rewriting the text to avoid obvious errors.

Shared memory accesses are "obviously" variable latency and "obviously" the MIO handles them. But MUFU instructions are fixed latency -- at least, the raw execution of the instruction within the SFU always takes K cycles for some K. But because these pipes are shared across SM sub-partitions in some SM architectures, they are potentially contended in a way that the compiler can't reason about, and so they are _effectively_ variable latency, thus requiring dependency tracking outside of the basic `stall_wait`. The MIO hardware, including its scoreboard, is repurposed to handle this contention, even though running `MUFU.EX2` is not a "memory in/out" operation in an obvious way like a read from shared memory.

So why don't the NVIDIA docs mention Tensor Core operations under `stall_short_scoreboard`, even though you can see barriers being set in their SASS? And why aren't there reports online? I don't have a great answer here, and I suspect that there's some way to trigger such a stall, perhaps by having two Tensor Cores try to read from the same Shared Memory addresses concurrently. But even then, maybe they don't use the MIO and have their own hardware for scoreboard management, which then gets reported under `stall_wait` for convenience?

That said, it's better not to claim that Tensor Core instructions show up in `stall_short_scoreboard` without evidence. I am comfortable saying that `stall_short_scoreboard` is triggered by variable latency instructions, based on the argument above for MUFU. We don't say much about `stall_wait`, so we avoid the need to disambiguate.