### PR TITLE
add article on Nsight Compute, expand Nsight Systems #43

### DIFF
--- a/gpu-glossary/host-software/cupti.md
+++ b/gpu-glossary/host-software/cupti.md
@@ -10,8 +10,11 @@ profiling execution of [CUDA C++](/gpu-glossary/host-software/cuda-c),
 Critically, it synchronizes timestamps across the CPU host and the GPU device.
 
 CUPTI's interfaces are consumed by, for example, the
-[NSight Systems Profiler](/gpu-glossary/host-software/nsight-systems) and the
+[Nsight Systems Profiler](/gpu-glossary/host-software/nsight-systems) and the
 [PyTorch Profiler](https://modal.com/docs/examples/torch_profiling).
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute) instead reserves
+the driver's performance monitor directly, and so contends with CUPTI clients
+for it.
 
 You can find its documentation [here](https://docs.nvidia.com/cupti/).
 

--- a/gpu-glossary/host-software/nsight-compute.md
+++ b/gpu-glossary/host-software/nsight-compute.md
@@ -1,0 +1,111 @@
+---
+title: What is NVIDIA Nsight Compute?
+---
+
+NVIDIA Nsight Compute is a profiler for individual
+[CUDA kernels](/gpu-glossary/device-software/kernel). Where
+[Nsight Systems](/gpu-glossary/host-software/nsight-systems) profiles an entire
+system and treats each [kernel](/gpu-glossary/device-software/kernel) as an
+opaque block on a timeline, Nsight Compute opens that block up: it reads the
+hardware performance counters of the
+[Streaming Multiprocessors (SMs)](/gpu-glossary/device-hardware/streaming-multiprocessor)
+to report what happened to a single
+[kernel](/gpu-glossary/device-software/kernel) launch, cycle by cycle and
+instruction by instruction.
+
+Put another way, [Nsight Systems](/gpu-glossary/host-software/nsight-systems)
+tells you _which_ [kernel](/gpu-glossary/device-software/kernel) to optimize.
+Nsight Compute tells you _why_ that
+[kernel](/gpu-glossary/device-software/kernel) is slow. It is usually a mistake
+to reach for the second tool before the first, since a perfectly-tuned
+[kernel](/gpu-glossary/device-software/kernel) that accounts for 2% of your
+runtime is worth nothing.
+
+Its reports are organized into _sections_, and the sections are a good map of
+the [performance](/gpu-glossary/perf) section of this glossary:
+
+- **GPU Speed of Light Throughput** compares achieved throughput against the
+  [peak rates](/gpu-glossary/perf/peak-rate) of the compute and memory
+  subsystems, including a [roofline chart](/gpu-glossary/perf/roofline-model),
+  which is the fastest way to tell whether a
+  [kernel](/gpu-glossary/device-software/kernel) is
+  [compute-bound](/gpu-glossary/perf/compute-bound) or
+  [memory-bound](/gpu-glossary/perf/memory-bound).
+- **Compute Workload Analysis** reports instructions per clock and the
+  [utilization of each pipe](/gpu-glossary/perf/pipe-utilization).
+- **Memory Workload Analysis** charts traffic between the
+  [SMs](/gpu-glossary/device-hardware/streaming-multiprocessor), the
+  [caches](/gpu-glossary/device-hardware/l1-data-cache), and
+  [GPU RAM](/gpu-glossary/device-hardware/gpu-ram), which is where
+  [uncoalesced accesses](/gpu-glossary/perf/memory-coalescing) and
+  [shared memory bank conflicts](/gpu-glossary/perf/bank-conflict) show up.
+- **Scheduler Statistics** and **Warp State Statistics** break down the
+  [states of the kernel's warps](/gpu-glossary/perf/warp-execution-state) — how
+  many were active, how many were eligible, how often an instruction was
+  actually [issued](/gpu-glossary/perf/issue-efficiency), and what the
+  [stalled](/gpu-glossary/perf/scoreboard-stall) ones were waiting on.
+- **Launch Statistics** summarizes the configuration the
+  [kernel](/gpu-glossary/device-software/kernel) was launched with — the
+  dimensions of its [grid](/gpu-glossary/device-software/thread-block-grid) and
+  [blocks](/gpu-glossary/device-software/thread-block) — along with the
+  [registers](/gpu-glossary/device-software/registers) and
+  [shared memory](/gpu-glossary/device-software/shared-memory) each
+  [block](/gpu-glossary/device-software/thread-block) consumed, and
+  **Occupancy** turns those into
+  [theoretical and achieved occupancy](/gpu-glossary/perf/occupancy).
+- **Source Counters** correlates metrics like
+  [branch efficiency](/gpu-glossary/perf/branch-efficiency) and sampled
+  [warp](/gpu-glossary/device-software/warp) stall reasons back to individual
+  [SASS](/gpu-glossary/device-software/streaming-assembler) instructions and, if
+  you compiled with line information, to lines of your
+  [CUDA C++](/gpu-glossary/host-software/cuda-c).
+
+Each section can carry _rules_, which are the "expert system" part of the tool:
+they inspect the collected metrics and emit prose recommendations, like a note
+that your [occupancy](/gpu-glossary/perf/occupancy) is limited by
+[shared memory](/gpu-glossary/device-software/shared-memory) rather than by
+[registers](/gpu-glossary/device-software/registers).
+
+All of this is expensive, in ways worth understanding. A GPU can only count so
+many things at once, so collecting a full set of metrics requires more than one
+pass over the [kernel](/gpu-glossary/device-software/kernel). Nsight Compute's
+default strategy is _kernel replay_: it saves the
+[global memory](/gpu-glossary/device-software/global-memory) the
+[kernel](/gpu-glossary/device-software/kernel) can reach, runs the launch again
+and again, and restores whatever the
+[kernel](/gpu-glossary/device-software/kernel) wrote between passes so that each
+pass sees identical inputs. It also serializes
+[kernel](/gpu-glossary/device-software/kernel) launches — only one
+[kernel](/gpu-glossary/device-software/kernel) at a time, and only one process
+profiling a given device at a time — and it locks
+[SM](/gpu-glossary/device-hardware/streaming-multiprocessor) clocks by default,
+for reproducibility.
+
+The consequences: profiling a single
+[kernel](/gpu-glossary/device-software/kernel) can take orders of magnitude
+longer than running it, wall-clock timings taken with host-side timers under the
+profiler are meaningless, and any performance effect that depends on
+[kernels](/gpu-glossary/device-software/kernel) running concurrently is
+invisible by construction. So you filter: profile a handful of launches of one
+[kernel](/gpu-glossary/device-software/kernel), not every launch in your
+program.
+
+Reading hardware counters is also a privileged operation. Nsight Compute must
+reserve the driver's performance monitor, which means administrator access on
+most systems — or a driver configured to permit non-admin profiling — and which
+it cannot share with other consumers of the same counters, like DCGM or a client
+of [CUPTI](/gpu-glossary/host-software/cupti)'s profiling API. The resulting
+`ERR_NVGPUCTRPERM` is the single most common thing standing between a programmer
+and their first profile.
+
+Nsight Compute ships as a GUI and as a command-line tool, `ncu`. It replaced
+`nvprof` and the NVIDIA Visual Profiler, which lose metric collection on GPUs of
+[compute capability](/gpu-glossary/device-software/compute-capability) 7.5 and
+don't support 8.0 or higher at all.
+
+You can find its documentation [here](https://docs.nvidia.com/nsight-compute/),
+in particular the
+[Kernel Profiling Guide](https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html),
+which doubles as a reference for the metrics it collects. For details on
+profiling GPU applications on Modal, see
+[our documentation](https://modal.com/docs/examples/torch_profiling).

--- a/gpu-glossary/host-software/nsight-systems.md
+++ b/gpu-glossary/host-software/nsight-systems.md
@@ -16,6 +16,60 @@ on top of the
 [CUDA Profiling Tools Interface](/gpu-glossary/host-software/cupti) are
 mission-critical.
 
+Nsight Systems profiles an entire _system_: both the CPU host and the GPU
+device, and, if you like, many processes and many GPUs across many nodes. Its
+central artifact is a timeline. On it you'll find
+
+- [CUDA Runtime](/gpu-glossary/host-software/cuda-runtime-api) and
+  [CUDA Driver](/gpu-glossary/host-software/cuda-driver-api) API calls made by
+  each host thread, like [kernel](/gpu-glossary/device-software/kernel) launches
+  and memory copies,
+- the corresponding device-side activity — which
+  [kernel](/gpu-glossary/device-software/kernel) was resident on which GPU when,
+  and for how long,
+- calls into libraries like [cuBLAS](/gpu-glossary/host-software/cublas),
+  [cuDNN](/gpu-glossary/host-software/cudnn), NCCL, and MPI,
+- user-defined ranges, via the NVIDIA Tools Extension (NVTX) API, which is how
+  framework-level operations from e.g. PyTorch get onto the timeline, and
+- CPU-side samples, with backtraces, plus operating system calls.
+
+Because it consumes the
+[CUDA Profiling Tools Interface](/gpu-glossary/host-software/cupti), which
+synchronizes timestamps across host and device, these tracks line up: you can
+see a host thread call into [`libcudart`](/gpu-glossary/host-software/libcudart)
+and watch the [kernel](/gpu-glossary/device-software/kernel) it launched appear
+on the device some microseconds later.
+
+Critically, Nsight Systems does not look inside those
+[kernels](/gpu-glossary/device-software/kernel). A
+[kernel](/gpu-glossary/device-software/kernel) is an opaque block on the
+timeline, annotated with its name, its duration, and the dimensions of its
+[thread block grid](/gpu-glossary/device-software/thread-block-grid) — not with
+anything about how its [warps](/gpu-glossary/device-software/warp) fared inside
+an [SM](/gpu-glossary/device-hardware/streaming-multiprocessor). That is
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute)'s job.
+
+So the questions Nsight Systems answers are the ones _between_ and _around_
+[kernels](/gpu-glossary/device-software/kernel). Is the GPU doing anything at
+all, or is it waiting on the host — that is, are we bound by
+[overhead](/gpu-glossary/perf/overhead)? Are there gaps between
+[kernels](/gpu-glossary/device-software/kernel) that
+[CUDA Graphs](/gpu-glossary/host-software/cuda-graph) could close? Do copies to
+the device overlap with computation, or serialize against it? Which
+[kernel](/gpu-glossary/device-software/kernel) actually dominates the run and is
+therefore worth optimizing at all?
+
+That last question is why Nsight Systems comes first in a performance
+engineering workflow. It traces rather than replays, and it neither serializes
+[kernel](/gpu-glossary/device-software/kernel) launches nor locks clocks, so its
+overhead is low and the durations it reports are close to the ones your users
+experience. Once it has identified a
+[kernel](/gpu-glossary/device-software/kernel) on the critical path that isn't
+meeting expectations, you hand that
+[kernel](/gpu-glossary/device-software/kernel) to
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute) — in the GUI,
+literally by right-clicking the launch on the timeline.
+
 You can find its documentation
 [here](https://docs.nvidia.com/nsight-systems/index.html), but
 [watching someone use the tool](https://www.youtube.com/watch?v=dUDGO66IadU) is

--- a/gpu-glossary/perf.md
+++ b/gpu-glossary/perf.md
@@ -27,5 +27,5 @@ that you need to understand to optimize the performance of programs running on
 GPUs.
 
 Roughly speaking, it should cover every term that you run across when using
-[NSight Compute](https://developer.nvidia.com/nsight-compute) to debug GPU
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute) to debug GPU
 [kernel](/gpu-glossary/device-software/kernel) performance issues.

--- a/gpu-glossary/perf/occupancy.md
+++ b/gpu-glossary/perf/occupancy.md
@@ -8,7 +8,8 @@ Occupancy is the ratio of the
 
 ![There are four warp slots per cycle on each of four clock cycles and so there are 16=4*4 total warp slots, and there are active warps in 15 of them, for an occupancy of ~94%. Diagram inspired by the [*CUDA Techniques to Maximize Compute and Instruction Throughput*](https://www.nvidia.com/en-us/on-demand/session/gtc25-s72685/) talk at GTC 2025.](themed-image://cycles.svg)
 
-There are two types of occupancy measurements:
+There are two types of occupancy measurements, both reported by
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute):
 
 - _Theoretical Occupancy_ represents the upper limit for occupancy due to the
   kernel launch configuration and device capabilities.

--- a/gpu-glossary/perf/overhead.md
+++ b/gpu-glossary/perf/overhead.md
@@ -17,7 +17,11 @@ TensorFlow spend time deciding which
 [kernel](/gpu-glossary/device-software/kernel) to launch, which can take many
 microseconds. We generally use the term
 ["host overhead"](https://modal.com/blog/host-overhead-inference-efficiency)
-here, though it's not entirely standardized.
+here, though it's not entirely standardized. Because overhead appears as gaps
+_between_ [kernels](/gpu-glossary/device-software/kernel), it is diagnosed with
+a system-wide profiler like
+[Nsight Systems](/gpu-glossary/host-software/nsight-systems) rather than with a
+[kernel](/gpu-glossary/device-software/kernel) profiler.
 [CUDA Graphs](/gpu-glossary/host-software/cuda-graph), which can collect a
 number of device-side [kernels](/gpu-glossary/device-software/kernel) together
 into a single host-side launch, are a common solution to these overheads. For

--- a/gpu-glossary/perf/pipe-utilization.md
+++ b/gpu-glossary/perf/pipe-utilization.md
@@ -25,7 +25,7 @@ programmers should first consider
 
 Pipe utilization is available in the
 `sm__inst_executed_pipe_*.avg.pct_of_peak_sustained_active` metrics from
-[NSight Compute](https://developer.nvidia.com/nsight-compute) (`ncu`), where the
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute) (`ncu`), where the
 asterisk represents specific pipelines like
 [`fma`](/gpu-glossary/device-hardware/cuda-core),
 [`tensor`](/gpu-glossary/device-hardware/tensor-core),

--- a/gpu-glossary/perf/roofline-model.md
+++ b/gpu-glossary/perf/roofline-model.md
@@ -50,8 +50,9 @@ importantly they vary depending on the subsystem, not just the system;
 [Tensor Cores](/gpu-glossary/device-hardware/tensor-core) have more FLOPS than
 [CUDA Cores](/gpu-glossary/device-hardware/cuda-core)).
 
-NVIDIA's NSight Compute tool for [kernel](/gpu-glossary/device-software/kernel)
-performance engineering automatically performs roofline analysis for profiled
+NVIDIA's [Nsight Compute](/gpu-glossary/host-software/nsight-compute) tool for
+[kernel](/gpu-glossary/device-software/kernel) performance engineering
+automatically performs roofline analysis for profiled
 [kernels](/gpu-glossary/device-software/kernel).
 
 The roofline model is deceptively simple. Note that, for instance, system

--- a/gpu-glossary/perf/scoreboard-stall.md
+++ b/gpu-glossary/perf/scoreboard-stall.md
@@ -60,9 +60,10 @@ There may be multiple scoreboards to barrier, such as `B01--4-` which means wait
 until scoreboards 0,1,4 are all cleared. When the data dependency has been
 satisfied, the respective scoreboard is decremented.
 
-Scoreboard reuse can mean that the stall classification from Nsight Compute is
-incorrect, as a long and short scoreboard stall may be conflated if they use the
-same scoreboard.
+Scoreboard reuse can mean that the stall classification from
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute) is incorrect, as a
+long and short scoreboard stall may be conflated if they use the same
+scoreboard.
 
 [Scoreboarding](https://www.cs.umd.edu/~meesh/411/website/projects/dynamic/scoreboard.html)
 for dependency tracking in dynamic instruction scheduling dates back to the

--- a/gpu-glossary/perf/warp-execution-state.md
+++ b/gpu-glossary/perf/warp-execution-state.md
@@ -4,7 +4,9 @@ title: What is warp execution state?
 
 The state of the [warps](/gpu-glossary/device-software/warp) running a
 [kernel](/gpu-glossary/device-software/kernel) is described with a number of
-non-exclusive adjectives: active, stalled, eligible, and selected.
+non-exclusive adjectives: active, stalled, eligible, and selected. These states,
+and the reasons for stalls in particular, are sampled and reported by
+[Nsight Compute](/gpu-glossary/host-software/nsight-compute).
 
 ![Warp execution states are indicated by color. Diagram inspired by the [*CUDA Techniques to Maximize Compute and Instruction Throughput*](https://www.nvidia.com/en-us/on-demand/session/gtc25-s72685/) talk at GTC 2025.](themed-image://cycles.svg)
 


### PR DESCRIPTION
Closes #43 

Makes the division of labor explicit: Nsight Systems profiles the whole system, host and device, and treats each kernel as an opaque block on a timeline; Nsight Compute opens that block up with the SMs' hardware performance counters. Nsight Systems tells you which kernel to optimize, Nsight Compute tells you why it's slow.

The Nsight Systems article gains what actually lands on the timeline (CUDA API calls, device activity, library and NVTX ranges, CPU samples), the explicit statement that it does not look inside kernels, and the hand-off to Nsight Compute.

The new Nsight Compute article walks its report sections, which double as a map of this glossary's performance section, then covers what the metrics cost: kernel replay, launch serialization, clock locking, and the performance-counter permissions behind ERR_NVGPUCTRPERM.

Also re-points the external Nsight Compute links in perf, roofline model, and pipe utilization at the new article, cross-links it from occupancy, warp execution state, scoreboard stall, and CUPTI, notes in overhead that gaps between kernels are a job for Nsight Systems, and corrects "NSight" to NVIDIA's "Nsight" throughout.