### PR TITLE
typo: Swap A and B in warp-divergence.md for correctness

### DIFF
--- a/gpu-glossary/perf/warp-divergence.md
+++ b/gpu-glossary/perf/warp-divergence.md
@@ -62,9 +62,9 @@ After loading the data into `R4` (`L1`), all 32
 (`L2`), and each [thread](/gpu-glossary/device-software/thread) gets its own
 `P0` value based on the `data` value in `R4`. Then, we have a bit of
 [compiler](/gpu-glossary/host-software/nvcc) cleverness: in `L3` _all_
-[threads](/gpu-glossary/device-software/thread) execute the code in A, writing
+[threads](/gpu-glossary/device-software/thread) execute the code in B, writing `data[idx] + 2`
 to `R0`. Only those for whom `P0` is true then execute the code in B (`L4`),
-over-writing the value written to `R0` in `L3`. On this instruction, the
+over-writing the value written in `L3` with `data[idx] * 4`. On this instruction, the
 [warp](/gpu-glossary/device-software/warp) is said to be "divergent". On `L5`,
 all [threads](/gpu-glossary/device-software/thread) are back to executing the
 same code. Once the


### PR DESCRIPTION
In the lines above, we have
```
        if (data[idx] > 0.5f) {
		    // A
            data[idx] = data[idx] * 4.0f;
        } else {
		    // B
            data[idx] = data[idx] + 2.0f;
        }
```

and 

```nasm
LDG.E.SYS R4, [R2]                       // L1 load data[idx]
FSETP.GT.AND P0, PT, R4.reuse, 0.5, PT   // L2 set P0 to data[idx] > 0.5
FADD R0, R4, 2                           // L3 store 2 + data[idx] in R0
@P0 FMUL R0, R4, 4                       // L4 in some threads, store 4 * data[idx] in R0
FMUL R5, R0, R0                          // L5 store R0 * R0 in R5
STG.E.SYS [R2], R5                       // L6 store R5 in data[idx]
```

The text originally said we write A and then overwrite with B, but the opposite is true. This PR swaps them for correctness.